### PR TITLE
hotfix: fix the the threshold check logic of WriteBinaryNocopy 

### DIFF
--- a/protocol/thrift/binary.go
+++ b/protocol/thrift/binary.go
@@ -118,7 +118,7 @@ func (BinaryProtocol) WriteBinary(buf, v []byte) int {
 }
 
 func (p BinaryProtocol) WriteBinaryNocopy(buf []byte, w NocopyWriter, v []byte) int {
-	if w == nil || len(buf) < NocopyWriteThreshold {
+	if w == nil || len(v) < nocopyWriteThreshold {
 		return p.WriteBinary(buf, v)
 	}
 	binary.BigEndian.PutUint32(buf, uint32(len(v)))

--- a/protocol/thrift/fastcodec.go
+++ b/protocol/thrift/fastcodec.go
@@ -22,11 +22,11 @@ import (
 	"github.com/bytedance/gopkg/lang/dirtmake"
 )
 
-// NocopyWriteThreshold represents the threshold of using `NocopyWriter` for binary or string
+// nocopyWriteThreshold represents the threshold of using `NocopyWriter` for binary or string
 //
 // It's used by `WriteBinaryNocopy` and `WriteStringNocopy` of `BinaryProtocol`
 // which are relied by kitex tool or thriftgo
-var NocopyWriteThreshold = 4096
+const nocopyWriteThreshold = 4096
 
 // BinaryWriter represents the method used in thrift encoding for nocopy writes
 // It supports netpoll nocopy feature, see: https://github.com/cloudwego/netpoll/blob/develop/nocopy.go


### PR DESCRIPTION
#### What type of PR is this?
<!--
Add one of the following kinds:

build: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
ci: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
docs: Documentation only changes
feat: A new feature
optimize: A new optimization
fix: A bug fix
perf: A code change that improves performance
refactor: A code change that neither fixes a bug nor adds a feature
style: Changes that do not affect the meaning of the code (white space, formatting, missing semi-colons, etc)
test: Adding missing tests or correcting existing tests
chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

#### Check the PR title.
<!--
The description of the title will be attached in Release Notes, 
so please describe it from user-oriented, what this PR does / why we need it.
Please check your PR title with the below requirements:
-->
- [ ] This PR title match the format: \<type\>(optional scope): \<description\>
- [ ] The description of this PR title is user-oriented and clear enough for others to understand.
- [ ] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en:
Kitex v0.11.0 has added a dependency on github.com/cloudwego/gopkg, and the thrift encoding logic has also been migrated to github.com/cloudwego/gopkg. However, the migrated code introduces a bug in the modification of WriteBinaryNocopy, resulting in all string/[]byte encodings executing WriteDirect after the total package exceeds 4k, leading to performance degradation. https://github.com/cloudwego/gopkg/pull/20 has been fixed.
Trigger scenario: Data package>4k, with many encoding logics for small strings
Impact point: CPU increases and has a significant impact on latency

zh(optional):
kitex v0.11.0 新增 github.com/cloudwego/gopkg 依赖，同时 thrift 编码逻辑也迁移至 github.com/cloudwego/gopkg，但迁移后的代码对 WriteBinaryNocopy 的修改引入了 bug，导致数据总包超过 4k 后，所有字符串/[]byte编码都会执行 WriteDirect，进而导致性能劣化。https://github.com/cloudwego/gopkg/pull/20 已经修复。
触发场景：数据总包 > 4k，有很多小字符串的编码逻辑
影响点：CPU 上升且对延迟有显著影响


#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
