### PR TITLE
perf: alloc strings from ttheader by bulk

### DIFF
--- a/protocol/ttheader/decode.go
+++ b/protocol/ttheader/decode.go
@@ -134,6 +134,12 @@ func IsTTHeader(flagBuf []byte) bool {
 }
 
 func readKVInfo(idx int, buf []byte) (intKVMap map[uint16]string, strKVMap map[string]string, err error) {
+	// realloc all the strings all at once
+	buf2 := make([]byte, len(buf)-idx)
+	copy(buf2, buf[idx:])
+	idx = 0
+	buf = buf2
+	// iter throght the buffer to read kv info
 	for {
 		var infoID uint8
 		infoID, err = Bytes2Uint8(buf, idx)
@@ -187,13 +193,14 @@ func readIntKVInfo(idx *int, buf []byte, info map[uint16]string) (has bool, err 
 	if kvSize <= 0 {
 		return false, nil
 	}
+
 	for i := uint16(0); i < kvSize; i++ {
 		key, err := Bytes2Uint16(buf, *idx)
 		*idx += 2
 		if err != nil {
 			return false, fmt.Errorf("error reading int kv info: %s", err.Error())
 		}
-		val, n, err := ReadString2BLen(buf, *idx)
+		val, n, err := ReadString2BLenUnsafe(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading int kv info: %s", err.Error())
@@ -212,13 +219,14 @@ func readStrKVInfo(idx *int, buf []byte, info map[string]string) (has bool, err 
 	if kvSize <= 0 {
 		return false, nil
 	}
+
 	for i := uint16(0); i < kvSize; i++ {
-		key, n, err := ReadString2BLen(buf, *idx)
+		key, n, err := ReadString2BLenUnsafe(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading str kv info: %s", err.Error())
 		}
-		val, n, err := ReadString2BLen(buf, *idx)
+		val, n, err := ReadString2BLenUnsafe(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading str kv info: %s", err.Error())
@@ -230,7 +238,7 @@ func readStrKVInfo(idx *int, buf []byte, info map[string]string) (has bool, err 
 
 // readACLToken reads acl token
 func readACLToken(idx *int, buf []byte, info map[string]string) error {
-	val, n, err := ReadString2BLen(buf, *idx)
+	val, n, err := ReadString2BLenUnsafe(buf, *idx)
 	*idx += n
 	if err != nil {
 		return fmt.Errorf("error reading acl token: %s", err.Error())

--- a/protocol/ttheader/decode.go
+++ b/protocol/ttheader/decode.go
@@ -139,7 +139,17 @@ func readKVInfo(idx int, buf []byte) (intKVMap map[uint16]string, strKVMap map[s
 	copy(buf2, buf[idx:])
 	idx = 0
 	buf = buf2
-	// iter throght the buffer to read kv info
+
+	// ACL token (if present) is stored in strKVMap, but the encoder writes it
+	// as a separate InfoIDACLToken segment that comes BEFORE InfoIDKeyValue.
+	// Defer materializing the ACL entry into strKVMap until after we've parsed
+	// any InfoIDKeyValue segment, so that strKVMap is allocated with the right
+	// size hint by readStrKVInfo (which already reserves +1 slot for the token).
+	var (
+		hasACLToken bool
+		aclToken    string
+	)
+	// iter through the buffer to read kv info
 	for {
 		var infoID uint8
 		infoID, err = Bytes2Uint8(buf, idx)
@@ -149,42 +159,46 @@ func readKVInfo(idx int, buf []byte) (intKVMap map[uint16]string, strKVMap map[s
 			if err == io.EOF {
 				err = nil
 			}
-			return
+			break
 		}
 		switch InfoIDType(infoID) {
 		case InfoIDPadding:
 			continue
 		case InfoIDKeyValue:
-			if strKVMap == nil {
-				strKVMap = make(map[string]string)
-			}
-			_, err = readStrKVInfo(&idx, buf, strKVMap)
+			_, err = readStrKVInfo(&idx, buf, &strKVMap)
 			if err != nil {
 				return
 			}
 		case InfoIDIntKeyValue:
-			if intKVMap == nil {
-				intKVMap = make(map[uint16]string)
-			}
-			_, err = readIntKVInfo(&idx, buf, intKVMap)
+			_, err = readIntKVInfo(&idx, buf, &intKVMap)
 			if err != nil {
 				return
 			}
 		case InfoIDACLToken:
-			if strKVMap == nil {
-				strKVMap = make(map[string]string)
-			}
-			if err = readACLToken(&idx, buf, strKVMap); err != nil {
+			var n int
+			aclToken, n, err = readString2BLenUnsafe(buf, idx)
+			if err != nil {
+				err = fmt.Errorf("error reading acl token: %s", err.Error())
 				return
 			}
+			idx += n
+			hasACLToken = true
 		default:
 			err = fmt.Errorf("invalid infoIDType[%#x]", infoID)
 			return
 		}
 	}
+
+	if hasACLToken {
+		if strKVMap == nil {
+			strKVMap = make(map[string]string, 1)
+		}
+		strKVMap[GDPRToken] = aclToken
+	}
+	return
 }
 
-func readIntKVInfo(idx *int, buf []byte, info map[uint16]string) (has bool, err error) {
+func readIntKVInfo(idx *int, buf []byte, infoPtr *map[uint16]string) (has bool, err error) {
 	kvSize, err := Bytes2Uint16(buf, *idx)
 	*idx += 2
 	if err != nil {
@@ -194,13 +208,20 @@ func readIntKVInfo(idx *int, buf []byte, info map[uint16]string) (has bool, err 
 		return false, nil
 	}
 
+	// Allocate the map lazily with kvSize as the size hint to avoid
+	// the runtime growing the map's bucket array as entries are inserted.
+	info := *infoPtr
+	if info == nil {
+		info = make(map[uint16]string, int(kvSize))
+		*infoPtr = info
+	}
 	for i := uint16(0); i < kvSize; i++ {
 		key, err := Bytes2Uint16(buf, *idx)
 		*idx += 2
 		if err != nil {
 			return false, fmt.Errorf("error reading int kv info: %s", err.Error())
 		}
-		val, n, err := ReadString2BLenUnsafe(buf, *idx)
+		val, n, err := readString2BLenUnsafe(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading int kv info: %s", err.Error())
@@ -210,7 +231,7 @@ func readIntKVInfo(idx *int, buf []byte, info map[uint16]string) (has bool, err 
 	return true, nil
 }
 
-func readStrKVInfo(idx *int, buf []byte, info map[string]string) (has bool, err error) {
+func readStrKVInfo(idx *int, buf []byte, infoPtr *map[string]string) (has bool, err error) {
 	kvSize, err := Bytes2Uint16(buf, *idx)
 	*idx += 2
 	if err != nil {
@@ -220,13 +241,23 @@ func readStrKVInfo(idx *int, buf []byte, info map[string]string) (has bool, err 
 		return false, nil
 	}
 
+	// Allocate the map lazily with kvSize+1 as the size hint to avoid the
+	// runtime growing the map's bucket array as entries are inserted. The +1
+	// reserves room for a possible GDPR token (InfoIDACLToken segment) that
+	// shares this same strKVMap; spending one extra slot when there's no
+	// token is cheaper than letting the map grow when there is one.
+	info := *infoPtr
+	if info == nil {
+		info = make(map[string]string, int(kvSize)+1)
+		*infoPtr = info
+	}
 	for i := uint16(0); i < kvSize; i++ {
-		key, n, err := ReadString2BLenUnsafe(buf, *idx)
+		key, n, err := readString2BLenUnsafe(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading str kv info: %s", err.Error())
 		}
-		val, n, err := ReadString2BLenUnsafe(buf, *idx)
+		val, n, err := readString2BLenUnsafe(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading str kv info: %s", err.Error())
@@ -234,17 +265,6 @@ func readStrKVInfo(idx *int, buf []byte, info map[string]string) (has bool, err 
 		info[key] = val
 	}
 	return true, nil
-}
-
-// readACLToken reads acl token
-func readACLToken(idx *int, buf []byte, info map[string]string) error {
-	val, n, err := ReadString2BLenUnsafe(buf, *idx)
-	*idx += n
-	if err != nil {
-		return fmt.Errorf("error reading acl token: %s", err.Error())
-	}
-	info[GDPRToken] = val
-	return nil
 }
 
 // protoID just for ttheader

--- a/protocol/ttheader/decode.go
+++ b/protocol/ttheader/decode.go
@@ -57,15 +57,18 @@ type DecodeParam struct {
 }
 
 // DecodeFromBytes decodes ttheader param from bytes.
-func DecodeFromBytes(ctx context.Context, bs []byte) (param DecodeParam, err error) {
+func DecodeFromBytes(ctx context.Context, bs []byte, opts ...DecodeOption) (param DecodeParam, err error) {
 	in := bufiox.NewBytesReader(bs)
-	param, err = Decode(ctx, in)
+	param, err = Decode(ctx, in, opts...)
 	_ = in.Release(nil)
 	return
 }
 
 // Decode decodes ttheader param from bufiox.Reader.
-func Decode(ctx context.Context, in bufiox.Reader) (param DecodeParam, err error) {
+// Optional DecodeOption values control string allocation strategy; see WithBulkStringAlloc.
+func Decode(ctx context.Context, in bufiox.Reader, opts ...DecodeOption) (param DecodeParam, err error) {
+	cfg := applyDecodeOptions(opts)
+
 	var headerMeta []byte
 	headerMeta, err = in.Next(TTHeaderMetaSize)
 	if err != nil {
@@ -110,7 +113,7 @@ func Decode(ctx context.Context, in bufiox.Reader) (param DecodeParam, err error
 		hdIdx++
 	}
 
-	param.IntInfo, param.StrInfo, err = readKVInfo(hdIdx, headerInfo)
+	param.IntInfo, param.StrInfo, err = readKVInfo(hdIdx, headerInfo, cfg)
 	if err != nil {
 		err = fmt.Errorf("ttHeader read kv info failed, %s, headerInfo=%#x", err.Error(), headerInfo)
 		return
@@ -133,12 +136,19 @@ func IsTTHeader(flagBuf []byte) bool {
 	return binary.BigEndian.Uint32(flagBuf[Size32:])&MagicMask == TTHeaderMagic
 }
 
-func readKVInfo(idx int, buf []byte) (intKVMap map[uint16]string, strKVMap map[string]string, err error) {
-	// realloc all the strings all at once
-	buf2 := make([]byte, len(buf)-idx)
-	copy(buf2, buf[idx:])
-	idx = 0
-	buf = buf2
+type readString2BLenFunc func(bytes []byte, off int) (string, int, error)
+
+func readKVInfo(idx int, buf []byte, cfg DecodeConfig) (intKVMap map[uint16]string, strKVMap map[string]string, err error) {
+	readStr := ReadString2BLen
+	if cfg.BulkStringAlloc {
+		// Own a single copy of the remaining KV region, then slice strings with
+		// unsafex so N fields share one backing allocation instead of N copies.
+		buf2 := make([]byte, len(buf)-idx)
+		copy(buf2, buf[idx:])
+		idx = 0
+		buf = buf2
+		readStr = readString2BLenUnsafe
+	}
 
 	// ACL token (if present) is stored in strKVMap, but the encoder writes it
 	// as a separate InfoIDACLToken segment that comes BEFORE InfoIDKeyValue.
@@ -165,18 +175,18 @@ func readKVInfo(idx int, buf []byte) (intKVMap map[uint16]string, strKVMap map[s
 		case InfoIDPadding:
 			continue
 		case InfoIDKeyValue:
-			_, err = readStrKVInfo(&idx, buf, &strKVMap)
+			_, err = readStrKVInfo(&idx, buf, &strKVMap, readStr)
 			if err != nil {
 				return
 			}
 		case InfoIDIntKeyValue:
-			_, err = readIntKVInfo(&idx, buf, &intKVMap)
+			_, err = readIntKVInfo(&idx, buf, &intKVMap, readStr)
 			if err != nil {
 				return
 			}
 		case InfoIDACLToken:
 			var n int
-			aclToken, n, err = readString2BLenUnsafe(buf, idx)
+			aclToken, n, err = readStr(buf, idx)
 			if err != nil {
 				err = fmt.Errorf("error reading acl token: %s", err.Error())
 				return
@@ -198,7 +208,7 @@ func readKVInfo(idx int, buf []byte) (intKVMap map[uint16]string, strKVMap map[s
 	return
 }
 
-func readIntKVInfo(idx *int, buf []byte, infoPtr *map[uint16]string) (has bool, err error) {
+func readIntKVInfo(idx *int, buf []byte, infoPtr *map[uint16]string, readStr readString2BLenFunc) (has bool, err error) {
 	kvSize, err := Bytes2Uint16(buf, *idx)
 	*idx += 2
 	if err != nil {
@@ -221,7 +231,7 @@ func readIntKVInfo(idx *int, buf []byte, infoPtr *map[uint16]string) (has bool, 
 		if err != nil {
 			return false, fmt.Errorf("error reading int kv info: %s", err.Error())
 		}
-		val, n, err := readString2BLenUnsafe(buf, *idx)
+		val, n, err := readStr(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading int kv info: %s", err.Error())
@@ -231,7 +241,7 @@ func readIntKVInfo(idx *int, buf []byte, infoPtr *map[uint16]string) (has bool, 
 	return true, nil
 }
 
-func readStrKVInfo(idx *int, buf []byte, infoPtr *map[string]string) (has bool, err error) {
+func readStrKVInfo(idx *int, buf []byte, infoPtr *map[string]string, readStr readString2BLenFunc) (has bool, err error) {
 	kvSize, err := Bytes2Uint16(buf, *idx)
 	*idx += 2
 	if err != nil {
@@ -252,12 +262,12 @@ func readStrKVInfo(idx *int, buf []byte, infoPtr *map[string]string) (has bool, 
 		*infoPtr = info
 	}
 	for i := uint16(0); i < kvSize; i++ {
-		key, n, err := readString2BLenUnsafe(buf, *idx)
+		key, n, err := readStr(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading str kv info: %s", err.Error())
 		}
-		val, n, err := readString2BLenUnsafe(buf, *idx)
+		val, n, err := readStr(buf, *idx)
 		*idx += n
 		if err != nil {
 			return false, fmt.Errorf("error reading str kv info: %s", err.Error())

--- a/protocol/ttheader/decode_option.go
+++ b/protocol/ttheader/decode_option.go
@@ -1,0 +1,50 @@
+// Copyright 2026 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ttheader
+
+// DecodeConfig controls TTHeader decode behavior.
+// Zero value keeps the historical safe path (per-string copy).
+type DecodeConfig struct {
+	// BulkStringAlloc, when true, copies the remaining KV header bytes into one
+	// owned buffer and builds map strings with unsafex.BinaryToString against
+	// that buffer. This cuts per-field string allocations. Strings then share
+	// the bulk buffer's backing array (immutable use only).
+	//
+	// Default false: each field uses a safe string([]byte) copy.
+	BulkStringAlloc bool
+}
+
+// DecodeOption mutates DecodeConfig for Decode / DecodeFromBytes.
+type DecodeOption func(*DecodeConfig)
+
+// WithBulkStringAlloc enables or disables bulk+unsafe string materialization.
+// Pass true only when callers treat returned StrInfo/IntInfo values as immutable
+// and do not retain them past ownership of the DecodeParam maps themselves
+// (the bulk backing buffer is owned by those strings via unsafe).
+func WithBulkStringAlloc(enable bool) DecodeOption {
+	return func(cfg *DecodeConfig) {
+		cfg.BulkStringAlloc = enable
+	}
+}
+
+func applyDecodeOptions(opts []DecodeOption) DecodeConfig {
+	var cfg DecodeConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}

--- a/protocol/ttheader/decode_test.go
+++ b/protocol/ttheader/decode_test.go
@@ -126,65 +126,114 @@ func TestDecodeHeaderSizeCheck(t *testing.T) {
 
 func BenchmarkDecodeFromBytes(b *testing.B) {
 	sizes := []int{16, 64, 512}
-
-	for _, n := range sizes {
-		b.Run("StrInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
-			benchmarkDecodeFromBytes(b, EncodeParam{
-				SeqID:      1,
-				ProtocolID: ProtocolIDThriftBinary,
-				StrInfo:    makeStrInfo(n, false),
-			})
-		})
+	modes := []struct {
+		name string
+		opts []DecodeOption
+	}{
+		{name: "SafeCopy", opts: nil},
+		{name: "BulkUnsafe", opts: []DecodeOption{WithBulkStringAlloc(true)}},
 	}
 
-	for _, n := range sizes {
-		b.Run("IntInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
-			benchmarkDecodeFromBytes(b, EncodeParam{
-				SeqID:      1,
-				ProtocolID: ProtocolIDThriftBinary,
-				IntInfo:    makeIntInfo(n),
+	for _, mode := range modes {
+		for _, n := range sizes {
+			b.Run(mode.name+"/StrInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+				benchmarkDecodeFromBytes(b, EncodeParam{
+					SeqID:      1,
+					ProtocolID: ProtocolIDThriftBinary,
+					StrInfo:    makeStrInfo(n, false),
+				}, mode.opts...)
 			})
-		})
-	}
+		}
 
-	// Mixed Str + Int with equal field counts.
-	for _, n := range sizes {
-		b.Run("StrAndIntInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
-			benchmarkDecodeFromBytes(b, EncodeParam{
-				SeqID:      1,
-				ProtocolID: ProtocolIDThriftBinary,
-				StrInfo:    makeStrInfo(n, false),
-				IntInfo:    makeIntInfo(n),
+		for _, n := range sizes {
+			b.Run(mode.name+"/IntInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+				benchmarkDecodeFromBytes(b, EncodeParam{
+					SeqID:      1,
+					ProtocolID: ProtocolIDThriftBinary,
+					IntInfo:    makeIntInfo(n),
+				}, mode.opts...)
 			})
-		})
-	}
+		}
 
-	// Str + GDPR token: encoder writes a separate InfoIDACLToken segment that
-	// shares strKVMap, exercising the +1 size hint path in readStrKVInfo.
-	for _, n := range sizes {
-		b.Run("StrInfoWithGDPR_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
-			benchmarkDecodeFromBytes(b, EncodeParam{
-				SeqID:      1,
-				ProtocolID: ProtocolIDThriftBinary,
-				StrInfo:    makeStrInfo(n, true),
+		// Mixed Str + Int with equal field counts.
+		for _, n := range sizes {
+			b.Run(mode.name+"/StrAndIntInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+				benchmarkDecodeFromBytes(b, EncodeParam{
+					SeqID:      1,
+					ProtocolID: ProtocolIDThriftBinary,
+					StrInfo:    makeStrInfo(n, false),
+					IntInfo:    makeIntInfo(n),
+				}, mode.opts...)
 			})
-		})
-	}
+		}
 
-	// Full mix: Str + Int + GDPR token.
-	for _, n := range sizes {
-		b.Run("MixedAll_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
-			benchmarkDecodeFromBytes(b, EncodeParam{
-				SeqID:      1,
-				ProtocolID: ProtocolIDThriftBinary,
-				StrInfo:    makeStrInfo(n, true),
-				IntInfo:    makeIntInfo(n),
+		// Str + GDPR token: encoder writes a separate InfoIDACLToken segment that
+		// shares strKVMap, exercising the +1 size hint path in readStrKVInfo.
+		for _, n := range sizes {
+			b.Run(mode.name+"/StrInfoWithGDPR_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+				benchmarkDecodeFromBytes(b, EncodeParam{
+					SeqID:      1,
+					ProtocolID: ProtocolIDThriftBinary,
+					StrInfo:    makeStrInfo(n, true),
+				}, mode.opts...)
 			})
-		})
+		}
+
+		// Full mix: Str + Int + GDPR token.
+		for _, n := range sizes {
+			b.Run(mode.name+"/MixedAll_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+				benchmarkDecodeFromBytes(b, EncodeParam{
+					SeqID:      1,
+					ProtocolID: ProtocolIDThriftBinary,
+					StrInfo:    makeStrInfo(n, true),
+					IntInfo:    makeIntInfo(n),
+				}, mode.opts...)
+			})
+		}
 	}
 }
 
-func benchmarkDecodeFromBytes(b *testing.B, param EncodeParam) {
+func TestDecodeBulkStringAllocMatchesSafe(t *testing.T) {
+	param := EncodeParam{
+		SeqID:      42,
+		ProtocolID: ProtocolIDThriftBinary,
+		StrInfo:    makeStrInfo(8, true),
+		IntInfo:    makeIntInfo(8),
+	}
+	buf, err := EncodeToBytes(context.Background(), param)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	binary.BigEndian.PutUint32(buf, uint32(len(buf)-4))
+
+	safe, err := DecodeFromBytes(context.Background(), buf)
+	if err != nil {
+		t.Fatalf("safe decode: %v", err)
+	}
+	bulk, err := DecodeFromBytes(context.Background(), buf, WithBulkStringAlloc(true))
+	if err != nil {
+		t.Fatalf("bulk decode: %v", err)
+	}
+	if safe.SeqID != bulk.SeqID || safe.ProtocolID != bulk.ProtocolID {
+		t.Fatalf("meta mismatch: safe=%+v bulk=%+v", safe, bulk)
+	}
+	if len(safe.StrInfo) != len(bulk.StrInfo) || len(safe.IntInfo) != len(bulk.IntInfo) {
+		t.Fatalf("map size mismatch str %d/%d int %d/%d",
+			len(safe.StrInfo), len(bulk.StrInfo), len(safe.IntInfo), len(bulk.IntInfo))
+	}
+	for k, v := range safe.StrInfo {
+		if bulk.StrInfo[k] != v {
+			t.Fatalf("StrInfo[%q]: safe=%q bulk=%q", k, v, bulk.StrInfo[k])
+		}
+	}
+	for k, v := range safe.IntInfo {
+		if bulk.IntInfo[k] != v {
+			t.Fatalf("IntInfo[%d]: safe=%q bulk=%q", k, v, bulk.IntInfo[k])
+		}
+	}
+}
+
+func benchmarkDecodeFromBytes(b *testing.B, param EncodeParam, opts ...DecodeOption) {
 	buf, err := EncodeToBytes(context.Background(), param)
 	if err != nil {
 		b.Fatalf("failed to encode: %v", err)
@@ -197,7 +246,7 @@ func benchmarkDecodeFromBytes(b *testing.B, param EncodeParam) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		if _, err := DecodeFromBytes(ctx, buf); err != nil {
+		if _, err := DecodeFromBytes(ctx, buf, opts...); err != nil {
 			b.Fatalf("failed to decode: %v", err)
 		}
 	}

--- a/protocol/ttheader/decode_test.go
+++ b/protocol/ttheader/decode_test.go
@@ -124,24 +124,72 @@ func TestDecodeHeaderSizeCheck(t *testing.T) {
 	}
 }
 
-func BenchmarkDecodeFromBytes_16Fields(b *testing.B) {
-	strInfo := make(map[string]string, 16)
-	for i := 0; i < 16; i++ {
-		strInfo["key"+strconv.Itoa(i)] = "value" + strconv.Itoa(i)
+func BenchmarkDecodeFromBytes(b *testing.B) {
+	sizes := []int{16, 64, 512}
+
+	for _, n := range sizes {
+		b.Run("StrInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+			benchmarkDecodeFromBytes(b, EncodeParam{
+				SeqID:      1,
+				ProtocolID: ProtocolIDThriftBinary,
+				StrInfo:    makeStrInfo(n, false),
+			})
+		})
 	}
 
-	encodeParam := EncodeParam{
-		SeqID:      1,
-		ProtocolID: ProtocolIDThriftBinary,
-		StrInfo:    strInfo,
+	for _, n := range sizes {
+		b.Run("IntInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+			benchmarkDecodeFromBytes(b, EncodeParam{
+				SeqID:      1,
+				ProtocolID: ProtocolIDThriftBinary,
+				IntInfo:    makeIntInfo(n),
+			})
+		})
 	}
 
-	// Pre-generate the byte payload
-	buf, err := EncodeToBytes(context.Background(), encodeParam)
+	// Mixed Str + Int with equal field counts.
+	for _, n := range sizes {
+		b.Run("StrAndIntInfo_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+			benchmarkDecodeFromBytes(b, EncodeParam{
+				SeqID:      1,
+				ProtocolID: ProtocolIDThriftBinary,
+				StrInfo:    makeStrInfo(n, false),
+				IntInfo:    makeIntInfo(n),
+			})
+		})
+	}
+
+	// Str + GDPR token: encoder writes a separate InfoIDACLToken segment that
+	// shares strKVMap, exercising the +1 size hint path in readStrKVInfo.
+	for _, n := range sizes {
+		b.Run("StrInfoWithGDPR_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+			benchmarkDecodeFromBytes(b, EncodeParam{
+				SeqID:      1,
+				ProtocolID: ProtocolIDThriftBinary,
+				StrInfo:    makeStrInfo(n, true),
+			})
+		})
+	}
+
+	// Full mix: Str + Int + GDPR token.
+	for _, n := range sizes {
+		b.Run("MixedAll_"+strconv.Itoa(n)+"Fields", func(b *testing.B) {
+			benchmarkDecodeFromBytes(b, EncodeParam{
+				SeqID:      1,
+				ProtocolID: ProtocolIDThriftBinary,
+				StrInfo:    makeStrInfo(n, true),
+				IntInfo:    makeIntInfo(n),
+			})
+		})
+	}
+}
+
+func benchmarkDecodeFromBytes(b *testing.B, param EncodeParam) {
+	buf, err := EncodeToBytes(context.Background(), param)
 	if err != nil {
 		b.Fatalf("failed to encode: %v", err)
 	}
-	// Set the total length field correctly as EncodeToBytes typically expects the caller to fill the first 4 bytes
+	// EncodeToBytes leaves the first 4 bytes (total length) for the caller to fill.
 	binary.BigEndian.PutUint32(buf, uint32(len(buf)-4))
 
 	ctx := context.Background()
@@ -149,9 +197,31 @@ func BenchmarkDecodeFromBytes_16Fields(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		_, err := DecodeFromBytes(ctx, buf)
-		if err != nil {
+		if _, err := DecodeFromBytes(ctx, buf); err != nil {
 			b.Fatalf("failed to decode: %v", err)
 		}
 	}
+}
+
+func makeStrInfo(n int, withGDPRToken bool) map[string]string {
+	size := n
+	if withGDPRToken {
+		size++
+	}
+	m := make(map[string]string, size)
+	for i := 0; i < n; i++ {
+		m["key"+strconv.Itoa(i)] = "value" + strconv.Itoa(i)
+	}
+	if withGDPRToken {
+		m[GDPRToken] = "gdpr_token_xxxxxxxx"
+	}
+	return m
+}
+
+func makeIntInfo(n int) map[uint16]string {
+	m := make(map[uint16]string, n)
+	for i := 0; i < n; i++ {
+		m[uint16(i)] = "value" + strconv.Itoa(i)
+	}
+	return m
 }

--- a/protocol/ttheader/decode_test.go
+++ b/protocol/ttheader/decode_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -120,5 +121,37 @@ func TestDecodeHeaderSizeCheck(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func BenchmarkDecodeFromBytes_16Fields(b *testing.B) {
+	strInfo := make(map[string]string, 16)
+	for i := 0; i < 16; i++ {
+		strInfo["key"+strconv.Itoa(i)] = "value" + strconv.Itoa(i)
+	}
+
+	encodeParam := EncodeParam{
+		SeqID:      1,
+		ProtocolID: ProtocolIDThriftBinary,
+		StrInfo:    strInfo,
+	}
+
+	// Pre-generate the byte payload
+	buf, err := EncodeToBytes(context.Background(), encodeParam)
+	if err != nil {
+		b.Fatalf("failed to encode: %v", err)
+	}
+	// Set the total length field correctly as EncodeToBytes typically expects the caller to fill the first 4 bytes
+	binary.BigEndian.PutUint32(buf, uint32(len(buf)-4))
+
+	ctx := context.Background()
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		_, err := DecodeFromBytes(ctx, buf)
+		if err != nil {
+			b.Fatalf("failed to decode: %v", err)
+		}
 	}
 }

--- a/protocol/ttheader/utils.go
+++ b/protocol/ttheader/utils.go
@@ -71,7 +71,7 @@ func ReadString2BLen(bytes []byte, off int) (string, int, error) {
 	return string(buf), int(length) + 2, nil
 }
 
-func ReadString2BLenUnsafe(bytes []byte, off int) (string, int, error) {
+func readString2BLenUnsafe(bytes []byte, off int) (string, int, error) {
 	length, err := Bytes2Uint16(bytes, off)
 	strLen := int(length)
 	if err != nil {

--- a/protocol/ttheader/utils.go
+++ b/protocol/ttheader/utils.go
@@ -71,6 +71,21 @@ func ReadString2BLen(bytes []byte, off int) (string, int, error) {
 	return string(buf), int(length) + 2, nil
 }
 
+func ReadString2BLenUnsafe(bytes []byte, off int) (string, int, error) {
+	length, err := Bytes2Uint16(bytes, off)
+	strLen := int(length)
+	if err != nil {
+		return "", 0, err
+	}
+	off += 2
+	if len(bytes)-off < strLen {
+		return "", 0, io.EOF
+	}
+
+	ret := unsafex.BinaryToString(bytes[off : off+strLen])
+	return ret, int(length) + 2, nil
+}
+
 // WriteByte ...
 func WriteByte(val byte, out bufiox.Writer) error {
 	var buf []byte


### PR DESCRIPTION
关键收益: 
- **MixedAll @ 512 fields:** 89.6µs → 28.5µs（−68%），1580 allocs → 8 allocs（−99.5%）
- **sec/op geomean**: −58.9%
- **B/op geomean**: −41.7%
- **allocs/op geomean**: −97.0%

优化点: 
1. KV 字符串走 bulk copy + unsafe view，消除每条 KV 的独立分配
2. `readStrKVInfo` / `readIntKVInfo` 在读到 `kvSize` 后再用 `kvSize+1` 作 size hint 创建 map，杜绝运行时 grow
3. ACL token 延迟到循环末尾才写入 `strKVMap`，混合 GDPR 场景下 size hint 仍然有效

```
goos: darwin
goarch: arm64
pkg: github.com/cloudwego/gopkg/protocol/ttheader
cpu: Apple M3 Pro
                                             │ /tmp/ttheader_main.txt │        /tmp/ttheader_new.txt         │
                                             │         sec/op         │    sec/op     vs base                │
DecodeFromBytes/StrInfo_16Fields-12                     1079.5n ±  2%   510.9n ±  0%  -52.67% (p=0.000 n=10)
DecodeFromBytes/StrInfo_64Fields-12                      4.594µ ±  2%   1.973µ ±  1%  -57.05% (p=0.000 n=10)
DecodeFromBytes/StrInfo_512Fields-12                     37.09µ ±  5%   15.35µ ±  1%  -58.62% (p=0.000 n=10)
DecodeFromBytes/IntInfo_16Fields-12                     1021.5n ±  4%   489.8n ±  2%  -52.05% (p=0.000 n=10)
DecodeFromBytes/IntInfo_64Fields-12                      4.538µ ±  3%   1.772µ ±  0%  -60.94% (p=0.000 n=10)
DecodeFromBytes/IntInfo_512Fields-12                     34.13µ ±  2%   14.41µ ±  5%  -57.77% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_16Fields-12               2124.0n ±  3%   951.9n ± 13%  -55.19% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_64Fields-12                9.340µ ±  8%   3.625µ ±  2%  -61.19% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_512Fields-12               73.29µ ±  1%   28.58µ ±  0%  -61.01% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_16Fields-12             1147.5n ±  6%   525.5n ±  5%  -54.21% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_64Fields-12              4.982µ ±  4%   1.927µ ±  0%  -61.32% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_512Fields-12             39.81µ ±  7%   15.05µ ±  1%  -62.19% (p=0.000 n=10)
DecodeFromBytes/MixedAll_16Fields-12                     2.216µ ± 20%   1.020µ ±  5%  -53.96% (p=0.000 n=10)
DecodeFromBytes/MixedAll_64Fields-12                    10.232µ ± 10%   3.702µ ±  2%  -63.82% (p=0.000 n=10)
DecodeFromBytes/MixedAll_512Fields-12                    89.60µ ±  6%   28.55µ ±  2%  -68.14% (p=0.000 n=10)
geomean                                                  7.693µ         3.160µ        -58.92%

                                             │ /tmp/ttheader_main.txt │        /tmp/ttheader_new.txt         │
                                             │          B/op          │     B/op      vs base                │
DecodeFromBytes/StrInfo_16Fields-12                      2.380Ki ± 0%   1.461Ki ± 0%  -38.61% (p=0.000 n=10)
DecodeFromBytes/StrInfo_64Fields-12                     10.795Ki ± 0%   5.856Ki ± 0%  -45.75% (p=0.000 n=10)
DecodeFromBytes/StrInfo_512Fields-12                     89.63Ki ± 0%   49.35Ki ± 0%  -44.94% (p=0.000 n=10)
DecodeFromBytes/IntInfo_16Fields-12                       1439.0 ± 0%     964.0 ± 0%  -33.01% (p=0.000 n=10)
DecodeFromBytes/IntInfo_64Fields-12                      6.532Ki ± 0%   3.789Ki ± 0%  -41.99% (p=0.000 n=10)
DecodeFromBytes/IntInfo_512Fields-12                     52.52Ki ± 0%   30.10Ki ± 0%  -42.68% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_16Fields-12                3.755Ki ± 0%   2.356Ki ± 0%  -37.24% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_64Fields-12               17.296Ki ± 0%   9.677Ki ± 0%  -44.05% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_512Fields-12              142.12Ki ± 0%   80.17Ki ± 0%  -43.59% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_16Fields-12              2.409Ki ± 0%   1.498Ki ± 0%  -37.82% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_64Fields-12             10.819Ki ± 0%   5.983Ki ± 0%  -44.70% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_512Fields-12             89.65Ki ± 0%   49.35Ki ± 0%  -44.95% (p=0.000 n=10)
DecodeFromBytes/MixedAll_16Fields-12                     3.783Ki ± 0%   2.394Ki ± 0%  -36.73% (p=0.000 n=10)
DecodeFromBytes/MixedAll_64Fields-12                    17.321Ki ± 0%   9.679Ki ± 0%  -44.12% (p=0.000 n=10)
DecodeFromBytes/MixedAll_512Fields-12                   142.14Ki ± 0%   80.17Ki ± 0%  -43.60% (p=0.000 n=10)
geomean                                                  14.34Ki        8.360Ki       -41.70%

                                             │ /tmp/ttheader_main.txt │       /tmp/ttheader_new.txt        │
                                             │       allocs/op        │ allocs/op   vs base                │
DecodeFromBytes/StrInfo_16Fields-12                       37.000 ± 0%   4.000 ± 0%  -89.19% (p=0.000 n=10)
DecodeFromBytes/StrInfo_64Fields-12                      138.000 ± 0%   5.000 ± 0%  -96.38% (p=0.000 n=10)
DecodeFromBytes/StrInfo_512Fields-12                    1051.000 ± 0%   5.000 ± 0%  -99.52% (p=0.000 n=10)
DecodeFromBytes/IntInfo_16Fields-12                       21.000 ± 0%   4.000 ± 0%  -80.95% (p=0.000 n=10)
DecodeFromBytes/IntInfo_64Fields-12                       74.000 ± 0%   5.000 ± 0%  -93.24% (p=0.000 n=10)
DecodeFromBytes/IntInfo_512Fields-12                     528.000 ± 0%   5.000 ± 0%  -99.05% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_16Fields-12                 57.000 ± 0%   6.000 ± 0%  -89.47% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_64Fields-12                212.000 ± 0%   8.000 ± 0%  -96.23% (p=0.000 n=10)
DecodeFromBytes/StrAndIntInfo_512Fields-12              1579.000 ± 0%   8.000 ± 0%  -99.49% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_16Fields-12               38.000 ± 0%   4.000 ± 0%  -89.47% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_64Fields-12              139.000 ± 0%   5.000 ± 0%  -96.40% (p=0.000 n=10)
DecodeFromBytes/StrInfoWithGDPR_512Fields-12            1052.000 ± 0%   5.000 ± 0%  -99.52% (p=0.000 n=10)
DecodeFromBytes/MixedAll_16Fields-12                      58.000 ± 0%   6.000 ± 0%  -89.66% (p=0.000 n=10)
DecodeFromBytes/MixedAll_64Fields-12                     213.000 ± 0%   8.000 ± 0%  -96.24% (p=0.000 n=10)
DecodeFromBytes/MixedAll_512Fields-12                   1580.000 ± 0%   8.000 ± 0%  -99.49% (p=0.000 n=10)
geomean                                                    183.6        5.554       -96.98%
```