### PR TITLE
fix(thrift): avoid panic on invalid skip type

### DIFF
--- a/protocol/thrift/binary.go
+++ b/protocol/thrift/binary.go
@@ -448,6 +448,10 @@ var typeToSize = [256]int8{
 	I64:    8,
 }
 
+func typeSize(t TType) int8 {
+	return typeToSize[uint8(t)]
+}
+
 func skipstr(p unsafe.Pointer, e uintptr) (int, error) {
 	if uintptr(p)+uintptr(4) <= e {
 		n := int(p2i32(p))
@@ -475,7 +479,7 @@ func skipType(p unsafe.Pointer, e uintptr, t TType, maxdepth int) (int, error) {
 	if maxdepth == 0 {
 		return 0, errDepthLimitExceeded
 	}
-	if n := typeToSize[t]; n > 0 {
+	if n := typeSize(t); n > 0 {
 		if uintptr(p)+uintptr(n) > e {
 			return 0, errBufferTooShort
 		}
@@ -493,7 +497,7 @@ func skipType(p unsafe.Pointer, e uintptr, t TType, maxdepth int) (int, error) {
 		if sz < 0 {
 			return 0, errDataLength
 		}
-		ksz, vsz := int(typeToSize[kt]), int(typeToSize[vt])
+		ksz, vsz := int(typeSize(kt)), int(typeSize(vt))
 		if ksz > 0 && vsz > 0 { // fast path, fast skip
 			mapkvsize := (int(sz) * (ksz + vsz))
 			if uintptr(p)+uintptr(6+mapkvsize) > e {
@@ -543,7 +547,7 @@ func skipType(p unsafe.Pointer, e uintptr, t TType, maxdepth int) (int, error) {
 		if sz < 0 {
 			return 0, errDataLength
 		}
-		vsz := int(typeToSize[vt])
+		vsz := int(typeSize(vt))
 		if vsz > 0 { // fast path, fast skip
 			listvsize := int(sz) * vsz
 			if uintptr(p)+uintptr(5+listvsize) > e {
@@ -586,8 +590,8 @@ func skipType(p unsafe.Pointer, e uintptr, t TType, maxdepth int) (int, error) {
 				return i, errBufferTooShort
 			}
 			fi := 0
-			if typeToSize[ft] > 0 {
-				fi = int(typeToSize[ft])
+			if typeSize(ft) > 0 {
+				fi = int(typeSize(ft))
 			} else if ft == STRING {
 				fi, err = skipstr(unsafe.Add(p, i), e)
 			} else {

--- a/protocol/thrift/binary_test.go
+++ b/protocol/thrift/binary_test.go
@@ -454,6 +454,19 @@ func TestBinarySkip(t *testing.T) {
 	// unknown type
 	_, err = Binary.Skip(b, TType(122))
 	assert.True(t, err != nil)
+
+	// invalid negative type
+	_, err = Binary.Skip([]byte{0}, TType(-106))
+	assert.True(t, err != nil)
+
+	// invalid negative nested types
+	invalidType := byte(150) // int8(150) == -106
+	_, err = Binary.Skip([]byte{invalidType, 0, 1, 0}, STRUCT)
+	assert.True(t, err != nil)
+	_, err = Binary.Skip([]byte{invalidType, byte(I32), 0, 0, 0, 1, 0, 0, 0, 1}, MAP)
+	assert.True(t, err != nil)
+	_, err = Binary.Skip([]byte{invalidType, 0, 0, 0, 1}, LIST)
+	assert.True(t, err != nil)
 }
 
 func TestNocopyWrite(t *testing.T) {

--- a/protocol/thrift/bufferreader.go
+++ b/protocol/thrift/bufferreader.go
@@ -258,7 +258,7 @@ func (r *BufferReader) skipType(t TType, maxdepth int) error {
 	if maxdepth == 0 {
 		return errDepthLimitExceeded
 	}
-	if n := typeToSize[t]; n > 0 {
+	if n := typeSize(t); n > 0 {
 		return r.skipn(int(n))
 	}
 	switch t {
@@ -272,7 +272,7 @@ func (r *BufferReader) skipType(t TType, maxdepth int) error {
 		if sz < 0 {
 			return errDataLength
 		}
-		ksz, vsz := int(typeToSize[kt]), int(typeToSize[vt])
+		ksz, vsz := int(typeSize(kt)), int(typeSize(vt))
 		if ksz > 0 && vsz > 0 {
 			return r.skipn(sz * (ksz + vsz))
 		}
@@ -307,7 +307,7 @@ func (r *BufferReader) skipType(t TType, maxdepth int) error {
 		if sz < 0 {
 			return errDataLength
 		}
-		if vsz := typeToSize[vt]; vsz > 0 {
+		if vsz := typeSize(vt); vsz > 0 {
 			return r.skipn(sz * int(vsz))
 		}
 		for j := 0; j < sz; j++ {
@@ -330,7 +330,7 @@ func (r *BufferReader) skipType(t TType, maxdepth int) error {
 			if ft == STOP {
 				return nil
 			}
-			if fsz := typeToSize[ft]; fsz > 0 {
+			if fsz := typeSize(ft); fsz > 0 {
 				err = r.skipn(int(fsz))
 			} else {
 				err = r.skipType(ft, maxdepth-1)

--- a/protocol/thrift/bufferreader_test.go
+++ b/protocol/thrift/bufferreader_test.go
@@ -255,5 +255,16 @@ func TestBinaryReaderSkip(t *testing.T) {
 		// unknown type
 		err = r.Skip(TType(122))
 		assert.True(t, err != nil)
+
+		// invalid negative type
+		r = NewBufferReader(bufiox.NewBytesReader([]byte{0}))
+		err = r.Skip(TType(-106))
+		assert.True(t, err != nil)
+
+		// invalid negative nested type
+		invalidType := byte(150) // int8(150) == -106
+		r = NewBufferReader(bufiox.NewBytesReader([]byte{invalidType, 0, 1, 0}))
+		err = r.Skip(STRUCT)
+		assert.True(t, err != nil)
 	}
 }

--- a/protocol/thrift/skipdecoder_test.go
+++ b/protocol/thrift/skipdecoder_test.go
@@ -175,6 +175,17 @@ func TestSkipDecoder(t *testing.T) {
 		// unknown type
 		_, err = r.Next(TType(122))
 		assert.True(t, err != nil)
+
+		// invalid negative type
+		r = NewSkipDecoder(bufiox.NewBytesReader([]byte{0}))
+		_, err = r.Next(TType(-106))
+		assert.True(t, err != nil)
+
+		// invalid negative nested type
+		invalidType := byte(150) // int8(150) == -106
+		r = NewSkipDecoder(bufiox.NewBytesReader([]byte{invalidType, 0, 1, 0}))
+		_, err = r.Next(STRUCT)
+		assert.True(t, err != nil)
 	}
 }
 

--- a/protocol/thrift/skipdecoder_tpl.go
+++ b/protocol/thrift/skipdecoder_tpl.go
@@ -40,7 +40,7 @@ func skipDecoderImpl[T skipDecoderIface](r T, t TType, maxdepth int) error {
 	if maxdepth == 0 {
 		return errDepthLimitExceeded
 	}
-	if sz := typeToSize[t]; sz > 0 {
+	if sz := typeSize(t); sz > 0 {
 		_, err := r.SkipN(int(sz))
 		return err
 	}
@@ -67,7 +67,7 @@ func skipDecoderImpl[T skipDecoderIface](r T, t TType, maxdepth int) error {
 			if tp == STOP {
 				break
 			}
-			if sz := typeToSize[tp]; sz > 0 {
+			if sz := typeSize(tp); sz > 0 {
 				// fastpath
 				// Field ID + Value
 				if _, err := r.SkipN(2 + int(sz)); err != nil {
@@ -94,7 +94,7 @@ func skipDecoderImpl[T skipDecoderIface](r T, t TType, maxdepth int) error {
 		if sz < 0 {
 			return errDataLength
 		}
-		ksz, vsz := int(typeToSize[kt]), int(typeToSize[vt])
+		ksz, vsz := int(typeSize(kt)), int(typeSize(vt))
 		if ksz > 0 && vsz > 0 {
 			_, err := r.SkipN(int(sz) * (ksz + vsz))
 			return err
@@ -128,7 +128,7 @@ func skipDecoderImpl[T skipDecoderIface](r T, t TType, maxdepth int) error {
 		if sz < 0 {
 			return errDataLength
 		}
-		if vsz := typeToSize[vt]; vsz > 0 {
+		if vsz := typeSize(vt); vsz > 0 {
 			_, err := r.SkipN(int(sz) * int(vsz))
 			return err
 		}


### PR DESCRIPTION
#### What this PR does

Avoid panics when thrift skip paths see an invalid negative `TType`. `TType` is an `int8`, so raw type bytes above 127 can become negative values such as `-106`. Indexing `typeToSize` with that value panics before the code can return a protocol error.

This PR indexes the fixed-size lookup table with `uint8(t)` and applies it to `BinaryProtocol.Skip`, `BufferReader.Skip`, and `SkipDecoder`. Invalid types still return the existing `unknown data type` protocol exception.

#### Tests

- `go test ./protocol/thrift`
- `go test ./...`