### PR TITLE
fix(connstate): support Windows remote close detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         go: [ "1.20", oldstable, stable ]
-        os: [ ubuntu-24.04-arm, ubuntu-latest ]
+        os: [ ubuntu-24.04-arm, ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/net/connstate/conn_test.go
+++ b/net/connstate/conn_test.go
@@ -114,6 +114,40 @@ func TestOnRemoteClosed(t *testing.T) {
 	assert.Nil(t, conn.Close())
 }
 
+// TestOnRemoteClosedWithoutRead verifies that connection closure is detected
+// independently of application reads. Server handlers rely on this behavior
+// while they are blocked on work other than reading from the client.
+func TestOnRemoteClosedWithoutRead(t *testing.T) {
+	ln, err := net.Listen("tcp", "localhost:0")
+	assert.Nil(t, err)
+	defer ln.Close()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	assert.Nil(t, err)
+	server, err := ln.Accept()
+	assert.Nil(t, err)
+
+	remoteClosed := make(chan struct{}, 1)
+	stater, err := ListenConnState(server, WithOnRemoteClosed(func() {
+		remoteClosed <- struct{}{}
+	}))
+	assert.Nil(t, err)
+
+	_, err = client.Write([]byte("unread data"))
+	assert.Nil(t, err)
+	assert.Nil(t, client.Close())
+
+	select {
+	case <-remoteClosed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("OnRemoteClosed callback was not invoked without a connection read")
+	}
+
+	assert.Equal(t, StateRemoteClosed, stater.State())
+	assert.Nil(t, stater.Close())
+	assert.Nil(t, server.Close())
+}
+
 // TestOnRemoteClosed_NotCalled tests that the OnRemoteClosed callback
 // is NOT invoked when the connection is closed locally.
 func TestOnRemoteClosed_NotCalled(t *testing.T) {

--- a/net/connstate/poll.go
+++ b/net/connstate/poll.go
@@ -44,6 +44,6 @@ func createPoller() {
 	}
 	go func() {
 		err := poll.wait()
-		fmt.Printf("gopkg.connstate epoll wait exit, err: %v\n", err)
+		fmt.Printf("gopkg.connstate poll wait exit, err: %v\n", err)
 	}()
 }

--- a/net/connstate/poll_windows.go
+++ b/net/connstate/poll_windows.go
@@ -14,22 +14,110 @@
 
 package connstate
 
-import "errors"
-
-var (
-	errNotSupportedForWindows = errors.New("connstate not supported for windows")
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+	"unsafe"
 )
 
-type mockWindowsPoller struct{}
+const (
+	windowsPollInterval = 10 * time.Millisecond
+	windowsPollErr      = 0x0001
+	windowsPollHUP      = 0x0002
+	windowsPollRDBand   = 0x0200
+)
 
-func (m *mockWindowsPoller) wait() error {
+var windowsWSAPoll = syscall.NewLazyDLL("ws2_32.dll").NewProc("WSAPoll")
+
+type windowsPollFD struct {
+	fd      uintptr
+	events  int16
+	revents int16
+}
+
+type windowsPoller struct {
+	mu        sync.Mutex
+	operators map[*fdOperator]struct{}
+}
+
+func (p *windowsPoller) wait() error {
+	var operators []*fdOperator
+	var events []windowsPollFD
+	for {
+		operators = operators[:0]
+		events = events[:0]
+
+		p.mu.Lock()
+		for operator := range p.operators {
+			operators = append(operators, operator)
+			events = append(events, windowsPollFD{
+				fd: uintptr(operator.fd),
+				// Request only out-of-band readability. Winsock always reports
+				// error conditions, including POLLHUP, while ordinary unread
+				// application data must not make this poller spin.
+				events: windowsPollRDBand,
+			})
+		}
+		var result uintptr
+		var callErr error
+		if len(events) > 0 {
+			result, _, callErr = windowsWSAPoll.Call(
+				uintptr(unsafe.Pointer(&events[0])),
+				uintptr(len(events)),
+				0,
+			)
+		}
+		p.mu.Unlock()
+		runtime.KeepAlive(events)
+		if int32(result) == -1 {
+			return callErr
+		}
+
+		var callbacks []OnRemoteClosed
+		if result > 0 {
+			for i := range events {
+				if events[i].revents&(windowsPollHUP|windowsPollErr) == 0 {
+					continue
+				}
+				operator := operators[i]
+				if conn := (*connStater)(atomic.LoadPointer(&operator.conn)); conn != nil {
+					if atomic.CompareAndSwapUint32(&conn.state, uint32(StateOK), uint32(StateRemoteClosed)) {
+						if conn.onRemoteClosed != nil {
+							callbacks = append(callbacks, conn.onRemoteClosed)
+						}
+					}
+				}
+			}
+		}
+		if len(callbacks) > 0 {
+			go func(callbacks []OnRemoteClosed) {
+				for _, callback := range callbacks {
+					callback()
+				}
+			}(callbacks)
+		}
+		pollcache.free()
+		time.Sleep(windowsPollInterval)
+	}
+}
+
+func (p *windowsPoller) control(fd *fdOperator, op op) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if op == opAdd {
+		p.operators[fd] = struct{}{}
+	} else {
+		delete(p.operators, fd)
+	}
 	return nil
 }
 
-func (m *mockWindowsPoller) control(fd *fdOperator, op op) error {
-	return errNotSupportedForWindows
-}
-
 func openpoll() (p poller, err error) {
-	return &mockWindowsPoller{}, nil
+	if err := windowsWSAPoll.Find(); err != nil {
+		return nil, err
+	}
+	return &windowsPoller{operators: make(map[*fdOperator]struct{})}, nil
 }


### PR DESCRIPTION
## Summary

- implement the Windows `connstate` poller with the native `WSAPoll` API, without consuming application data
- serialize socket registration/removal with each nonblocking poll so handles cannot be closed or reused during the syscall
- preserve the existing one-shot `StateRemoteClosed` callback semantics
- add a regression test for disconnect detection with unread data and no application `Read`
- add `windows-latest` to the Go 1.20/oldstable/stable unit-test matrix

## Design notes

The poll requests only `POLLRDBAND`; Winsock reports `POLLHUP` and `POLLERR` independently, so normal unread application data does not create a busy loop. Polling is nonblocking and runs at the existing 10 ms detection interval. No new dependency is introduced.

Microsoft API documentation: https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsapoll

Fixes #73

## Test plan

- [x] Windows amd64, Go 1.26.4: `go test -race -count=1 ./...`
- [x] Linux amd64, Go 1.26.0: `go test -race -count=1 ./...`
- [x] `go vet ./net/connstate`
- [x] golangci-lint v2.12.2 on the PR diff: 0 issues
- [x] downstream Hertz v0.10.5 streaming disconnect regression: `-race -count=20`
- [ ] GitHub Actions Windows matrix, including Go 1.20